### PR TITLE
include elf and port arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,5 @@ dmypy.json
 /pyx2cscope/examples/scope_data.csv
 /doc/_build/
 /doc/source/
-/pyx2cscope/examples/config.ini
-/pyx2cscope/gui/web/upload/
+**/web/upload/
+**/config.ini

--- a/pyx2cscope/__main__.py
+++ b/pyx2cscope/__main__.py
@@ -8,14 +8,9 @@ import logging
 logging.basicConfig(level=logging.ERROR)
 
 import argparse
-import sys
-
-from PyQt5.QtWidgets import QApplication
 
 import pyx2cscope
-from pyx2cscope.gui.watchView.minimal_gui import X2cscopeGui
-from pyx2cscope.gui.web import app
-
+from pyx2cscope import gui, utils
 
 def parse_arguments():
     """Forward the received arguments to ArgParse and parse them.
@@ -37,11 +32,15 @@ def parse_arguments():
                         help="Configure the logging level, INFO is the default value.")
     parser.add_argument("-c", "--log-console", action="store_true",
                         help="Output log to the console.")
+    parser.add_argument("-e", "--elf", 
+                        help="Path to elf-file, i.e. -e my_elf.elf. Use together with -s")
+    parser.add_argument("-p", "--port", 
+                        help="The serial COM port to be used. Use together with -e")
     parser.add_argument("-q", "--qt", action="store_false",
                         help="Start the Qt user interface, pyx2cscope.gui.watch_view.minimal_gui.")
     parser.add_argument("-w", "--web", action="store_true",
                         help="Start the Web user interface, pyx2cscope.gui.web.app.")
-    parser.add_argument("-p", "--port", type=int, default="5000",
+    parser.add_argument("-wp", "--web-port", type=int, default="5000",
                         help="Configure the Web Server port. Use together with -w")
     parser.add_argument("--host", type=str, default="localhost",
                         help="Configure the Web Server address. Use together with -w")
@@ -50,42 +49,41 @@ def parse_arguments():
 
     return parser.parse_known_args()
 
-def execute_qt(args):
-    """Execute the GUI Qt implementation.
 
-    Args:
-        args: non-keyed arguments for Qt App.
-    :return:
-    """
-    # QApplication expects the first argument to be the program name.
-    qt_args = sys.argv[:1] + args
-    # Initialize a PyQt5 application
-    app = QApplication(qt_args)
-    # Create an instance of the X2Cscope_GUI
-    ex = X2cscopeGui()
-    # Display the GUI
-    ex.show()
-    # Start the PyQt5 application event loop
-    app.exec_()
+def _args_check(k_args: argparse.Namespace):
+    # if both elf and port are not supplied, check if there is a valid config file
+    if k_args.elf is None and k_args.port is None:
+        path = utils.get_elf_file_path()
+        com_port = utils.get_com_port()
+        if path and com_port:
+            k_args.elf = path
+            k_args.port = com_port
+    # if we supplied and elf but no port
+    elif k_args.elf and not k_args.port:
+        com_port = utils.get_com_port()
+        if com_port:
+            k_args.port = com_port
+        else:
+            raise ValueError("A communication port must be supplied!")
+    elif not k_args.elf and k_args.port:
+        path = utils.get_elf_file_path()
+        if path:
+            k_args.elf = path
+        else:
+            raise ValueError("An elf-file path must be supplied!")
 
-def execute_web(*args, **kwargs):
-    """Start the web server.
-
-    Args:
-        *args: non-keyed arguments
-        **kwargs: keyed arguments related to the web server. See parse_arguments function documentations.
-    """
-    app.main(*args, **kwargs)
 
 known_args, unknown_args = parse_arguments()
+# if arguments logic is correct,
+_args_check(known_args)
 
 logging.root.handlers.clear()
 pyx2cscope.set_logger(level=known_args.log_level, console=known_args.log_console)
 
 if known_args.qt and not known_args.web:
-    execute_qt(unknown_args)
+    gui.execute_qt(unknown_args, **known_args.__dict__)
 
 if known_args.web:
-    execute_web(**known_args.__dict__)
+    gui.execute_web(**known_args.__dict__)
 
 

--- a/pyx2cscope/examples/SFR_Example.py
+++ b/pyx2cscope/examples/SFR_Example.py
@@ -3,7 +3,7 @@
 import logging
 import time
 
-from utils import get_com_port, get_elf_file_path
+from pyx2cscope.utils import get_com_port, get_elf_file_path
 
 from pyx2cscope.xc2scope import X2CScope
 

--- a/pyx2cscope/examples/exampleMCAF.py
+++ b/pyx2cscope/examples/exampleMCAF.py
@@ -5,8 +5,7 @@ this example is the very basic example to retrieve the value of a certain variab
 
 import logging
 
-from utils import get_com_port, get_elf_file_path
-
+from pyx2cscope.utils import get_com_port, get_elf_file_path
 from pyx2cscope.xc2scope import X2CScope
 
 # Configure logging settings to capture all levels of log messages and write them to a file

--- a/pyx2cscope/examples/live_scope.py
+++ b/pyx2cscope/examples/live_scope.py
@@ -5,7 +5,7 @@ import logging
 import time
 
 import matplotlib.pyplot as plt
-from utils import get_com_port, get_elf_file_path
+from pyx2cscope.utils import get_com_port, get_elf_file_path
 
 from pyx2cscope.xc2scope import X2CScope
 

--- a/pyx2cscope/examples/plotting_and_saving.py
+++ b/pyx2cscope/examples/plotting_and_saving.py
@@ -12,7 +12,7 @@ import time
 import matplotlib.pyplot as plt
 import pandas as pd
 from matplotlib import animation
-from utils import get_com_port, get_elf_file_path
+from pyx2cscope.utils import get_com_port, get_elf_file_path
 
 from pyx2cscope.xc2scope import X2CScope
 

--- a/pyx2cscope/examples/pyX2CScope_demo.py
+++ b/pyx2cscope/examples/pyX2CScope_demo.py
@@ -9,7 +9,7 @@ import logging
 import time
 
 import matplotlib.pyplot as plt
-from utils import get_com_port, get_elf_file_path
+from pyx2cscope.utils import get_com_port, get_elf_file_path
 from pyx2cscope import set_logger
 
 from pyx2cscope.xc2scope import X2CScope

--- a/pyx2cscope/examples/testingArray.py
+++ b/pyx2cscope/examples/testingArray.py
@@ -2,8 +2,8 @@
 import logging
 
 import matplotlib.pyplot as plt
-from utils import get_com_port, get_elf_file_path
-from xc2scope import X2CScope
+from pyx2cscope.utils import get_com_port, get_elf_file_path
+from pyx2cscope.xc2scope import X2CScope
 
 # Set up logging
 logging.basicConfig(

--- a/pyx2cscope/gui/__init__.py
+++ b/pyx2cscope/gui/__init__.py
@@ -1,1 +1,36 @@
 """This module is for all the different GUI."""
+
+def execute_qt(*args, **kwargs):
+    """Execute the default Qt GUI interface.
+
+    Args:
+        args: non-keyed arguments for Qt App.
+        kwargs: keyed arguments for Qt App.
+
+    :return:
+    """
+    import sys
+    from PyQt5.QtWidgets import QApplication
+    from pyx2cscope.gui.watchView.minimal_gui import X2cscopeGui
+
+    # QApplication expects the first argument to be the program name.
+    qt_args = sys.argv[:1] + args[0]
+    # Initialize a PyQt5 application
+    app = QApplication(qt_args)
+    # Create an instance of the X2Cscope_GUI
+    ex = X2cscopeGui(*args, **kwargs)
+    # Display the GUI
+    ex.show()
+    # Start the PyQt5 application event loop
+    app.exec_()
+
+
+def execute_web(*args, **kwargs):
+    """Start the web server.
+
+    Args:
+        *args: non-keyed arguments
+        **kwargs: keyed arguments related to the web server. See parse_arguments function documentations.
+    """
+    from pyx2cscope.gui.web import app
+    app.main(*args, **kwargs)

--- a/pyx2cscope/gui/watchView/minimal_gui.py
+++ b/pyx2cscope/gui/watchView/minimal_gui.py
@@ -45,7 +45,7 @@ class X2cscopeGui(QMainWindow):
     to connect to a microcontroller, select variables for monitoring, and plot their values.
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """Initializing all the elements required."""
         super().__init__()
         self.initialize_variables()

--- a/pyx2cscope/utils.py
+++ b/pyx2cscope/utils.py
@@ -17,8 +17,8 @@ def get_config_file() -> ConfigParser:
         ConfigParser: The configuration parser object.
     """
     config_file = "config.ini"
-    default_path = {"path": "'path_to_your_elf_file'"}
-    default_com = {"com_port": "your_com_port, ex:'COM3'"}
+    default_path = {"path": "path_to_your_elf_file"}
+    default_com = {"com_port": "your_com_port, ex:COM3"}
     config = ConfigParser()
     if os.path.exists(config_file):
         config.read(config_file)
@@ -42,6 +42,8 @@ def get_elf_file_path(key="path") -> str:
         str: The path to the ELF file.
     """
     config = get_config_file()
+    if not config["ELF_FILE"][key] or "your" in config["ELF_FILE"][key]:
+        return ""
     return config["ELF_FILE"][key]
 
 
@@ -55,4 +57,6 @@ def get_com_port(key="com_port") -> str:
         str: The COM port.
     """
     config = get_config_file()
+    if not config["COM_PORT"][key] or "your" in config["COM_PORT"][key]:
+        return ""
     return config["COM_PORT"][key]


### PR DESCRIPTION
Made a clean-up on the main file.
No modules are loaded and according to user selection, the respective module is loaded and executed.

Arguments -e --elf and -p --port have being included. Additionally, the utils module was moved from examples to the main pyX2Cscope module. So the elf file and port configuration over config.ini can be called.

A small logic for elf file and port was also added, see _args_check()

resolves #40 