### PR TITLE
Feat connect without elf

### DIFF
--- a/pyx2cscope/examples/simplest_no_elf.py
+++ b/pyx2cscope/examples/simplest_no_elf.py
@@ -1,0 +1,39 @@
+"""The simplest usage of the pyX2Cscope library without using and elf_file.
+
+The script initializes the X2CScope class with a specified serial port without ELF file.
+At this way, we can't know which variables are available on the processor, but we can
+get connection info, processor id, and x2cscope version.
+
+It is possible to set later the path to and elf file through method set_elf_file
+"""
+
+from pyx2cscope.x2cscope import X2CScope
+
+# initialize the X2CScope class with serial port, by default baud rate is 115200
+x2c_scope = X2CScope(port="COM32")
+
+# Read device_info
+device_info = x2c_scope.get_device_info()
+
+# Print the controller info
+# i.e.: {
+#   'processor_id': '__GENERIC_MICROCHIP_PIC32__',
+#   'uc_width': '32-bit',
+#   'date': 'Mar 32019',
+#   'time': '1220',
+#   'AppVer': 1,
+#   'dsp_state': 'Application runs on target'
+#   }
+print(device_info)
+
+# set the elf_file later, post instantiation
+x2c_scope.set_elf_file("""your_path_to_elf_file.elf""")
+
+# Collect some variables, i.e.: from QSPIN on SAME54 MCLV-48V-300W
+angle_reference = x2c_scope.get_variable("mcFocI_ModuleData_gds.dOutput.elecAngle")
+speed_measured = x2c_scope.get_variable("mcFocI_ModuleData_gds.dOutput.elecSpeed")
+
+# Read the value of the "motor.apiData.velocityMeasured" variable from the target
+print(speed_measured.get_value())
+
+

--- a/pyx2cscope/parser/elf_parser.py
+++ b/pyx2cscope/parser/elf_parser.py
@@ -114,3 +114,20 @@ class ElfParser(ABC):
         Returns:
             Dict[str, VariableInfo]: A dictionary of variable names to VariableInfo objects.
         """
+
+class DummyParser(ElfParser):
+    """Dummy implementation of ElfParser class.
+
+    This class provides basic functionality of a parser in case an elf_file is
+    not supplied. It is a pure implementation of class ElfParser.
+    """
+
+    def __init__(self, elf_path = ""):
+        """DummyParser constructor takes no argument."""
+        super().__init__(elf_path = elf_path)
+
+    def _load_elf_file(self):
+        pass
+
+    def _map_variables(self) -> Dict[str, VariableInfo]:
+        return {}

--- a/pyx2cscope/variable/variable_factory.py
+++ b/pyx2cscope/variable/variable_factory.py
@@ -63,6 +63,7 @@ class VariableFactory:
 
         Args:
             elf_path (str): Path to the elf file.
+
         Returns:
             None
         """

--- a/pyx2cscope/variable/variable_factory.py
+++ b/pyx2cscope/variable/variable_factory.py
@@ -4,6 +4,7 @@ import logging
 
 from mchplnet.lnet import LNet
 from mchplnet.services.frame_device_info import DeviceInfo
+from parser.elf_parser import DummyParser
 from pyx2cscope.parser.elf16_parser import Elf16Parser
 from pyx2cscope.parser.elf32_parser import Elf32Parser
 from pyx2cscope.variable.variable import (
@@ -46,16 +47,30 @@ class VariableFactory:
         """
         self.l_net = l_net
         self.device_info = self.l_net.get_device_info()
-        parser = (
-            Elf16Parser
-            if self.device_info.uc_width == DeviceInfo.MACHINE_16
-            else Elf32Parser
-        )
         if (
             self.device_info.processor_id == "__GENERIC_MICROCHIP_DSPIC__"
         ):  # TODO implement it better for future cores.
             self.device_info.uc_width = 2
 
+        # we should be able to initialize without using and elf file
+        if elf_path is None:
+            self.parser = DummyParser()
+        else:
+            self.set_elf_file(elf_path)
+
+    def set_elf_file(self, elf_path: str):
+        """Set an elf file to be used as source for variables and addresses.
+
+        Args:
+            elf_path (str): Path to the elf file.
+        Returns:
+            None
+        """
+        parser = (
+            Elf16Parser
+            if self.device_info.uc_width == DeviceInfo.MACHINE_16
+            else Elf32Parser
+        )
         self.parser = parser(elf_path)
 
     def get_var_list(self) -> list[str]:

--- a/pyx2cscope/variable/variable_factory.py
+++ b/pyx2cscope/variable/variable_factory.py
@@ -4,7 +4,7 @@ import logging
 
 from mchplnet.lnet import LNet
 from mchplnet.services.frame_device_info import DeviceInfo
-from parser.elf_parser import DummyParser
+from pyx2cscope.parser.elf_parser import DummyParser
 from pyx2cscope.parser.elf16_parser import Elf16Parser
 from pyx2cscope.parser.elf32_parser import Elf32Parser
 from pyx2cscope.variable.variable import (

--- a/pyx2cscope/x2cscope.py
+++ b/pyx2cscope/x2cscope.py
@@ -83,7 +83,7 @@ class X2CScope:
         convert_list (dict): Dictionary to store variable conversion functions.
     """
 
-    def __init__(self, elf_file: str, interface: InterfaceABC = None, **kwargs):
+    def __init__(self, elf_file: str = None, interface: InterfaceABC = None, **kwargs):
         """Initialize the X2CScope instance.
 
         Args:
@@ -98,7 +98,7 @@ class X2CScope:
         self.variable_factory = VariableFactory(self.lnet, elf_file)
         self.scope_setup = self.lnet.get_scope_setup()
         self.convert_list = {}
-        self.ucwidth = self.variable_factory.device_info.uc_width
+        self.uc_width = self.variable_factory.device_info.uc_width
 
     def set_interface(self, interface: InterfaceABC):
         """Set the communication interface for the scope.
@@ -116,7 +116,7 @@ class X2CScope:
         Args:
             elf_file (str): Path to the ELF file.
         """
-        self.variable_factory = VariableFactory(self.lnet, elf_file)
+        self.variable_factory.set_elf_file(elf_file)
 
     def connect(self):
         """Establish a connection with the scope interface."""
@@ -268,7 +268,7 @@ class X2CScope:
         scope_data: LoadScopeData = self.lnet.scope_data
         return int(
             scope_data.trigger_event_position
-            / (self.scope_setup.get_dataset_size() / self.ucwidth)
+            / (self.scope_setup.get_dataset_size() / self.uc_width)
         )
 
     def get_delay_trigger_position(self) -> int:
@@ -287,7 +287,7 @@ class X2CScope:
             int: The length of the used portion of the SDA.
         """
         bytes_not_used = self.lnet.scope_data.data_array_size % (
-            self.scope_setup.get_dataset_size() / self.ucwidth
+            self.scope_setup.get_dataset_size() / self.uc_width
         )
         return self.lnet.scope_data.data_array_size - bytes_not_used
 


### PR DESCRIPTION
from pyx2cscope.x2cscope import X2CScope

```
initialize the X2CScope class with serial port, by default baud rate is 115200
**x2c_scope = X2CScope(port="COM32")** # <- without elf

# Read device_info
device_info = x2c_scope.get_device_info()

# Print the controller info
# i.e.: {
#   'processor_id': '__GENERIC_MICROCHIP_PIC32__',
#   'uc_width': '32-bit',
#   'date': 'Mar 32019',
#   'time': '1220',
#   'AppVer': 1,
#   'dsp_state': 'Application runs on target'
#   }
print(device_info)

# set the elf_file later, post instantiation
x2c_scope.set_elf_file("""your_path_to_elf_file.elf""")** # <- load elf file later on

# Collect some variables, i.e.: from QSPIN on SAME54 MCLV-48V-300W
angle_reference = x2c_scope.get_variable("mcFocI_ModuleData_gds.dOutput.elecAngle")
speed_measured = x2c_scope.get_variable("mcFocI_ModuleData_gds.dOutput.elecSpeed")

# Read the value of the "motor.apiData.velocityMeasured" variable from the target
print(speed_measured.get_value())
```