### PR TITLE
Fix struct enum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyx2cscope"
-version = "0.4.1"
+version = "0.4.2"
 description = "python implementation of X2Cscope"
 authors = [
   "Yash Agarwal <yash.agarwal@microchip.com>",

--- a/pyx2cscope/__init__.py
+++ b/pyx2cscope/__init__.py
@@ -1,11 +1,11 @@
 """This module contains the pyx2cscope package.
 
-Version: 0.4.1
+Version: 0.4.2
 """
 
 import logging
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 def set_logger(

--- a/pyx2cscope/parser/generic_parser.py
+++ b/pyx2cscope/parser/generic_parser.py
@@ -46,12 +46,10 @@ class GenericParser(ElfParser):
         - self.die_variable
         - self.var_name
         - self.address
-        - self.type_attr
         """
         self.die_variable = None
         self.var_name = None
         self.address = None
-        self.type_attr = None
 
         # In DIE structure, a variable to be considered valid, has under
         # its attributes the attribute DW_AT_specification or DW_AT_location
@@ -88,32 +86,29 @@ class GenericParser(ElfParser):
 
         self.var_name = self.die_variable.attributes.get("DW_AT_name").value.decode("utf-8")
         self.address = self._extract_address(die_variable)
-        self.type_attr = self.die_variable.attributes.get("DW_AT_type")
 
     def _process_variable_die(self, die_variable):
         """Process an individual variable DIE."""
         self._get_die_variable_details(die_variable)
-        if self.type_attr is None:
-            return []
+        if self.address is None:
+            return
 
-        ref_addr = self.type_attr.value + self.die_variable.cu.cu_offset
-        type_die = self.dwarf_info.get_DIE_from_refaddr(ref_addr)
-        end_die = self._get_end_die(die_variable)
+        member = {}
+        self._process_end_die(member, die_variable, 0, 0, self.var_name)
 
-        # try to get variable data on end_die
-        if end_die is not None and end_die.tag is not None:
-            return self._process_end_die(end_die)
-
-        # try to get variable data on type_die
-        end_die = self._get_end_die(type_die)
-        if end_die:
-            return self._process_end_die(end_die)
-
-        # no data found
-        logging.warning(
-            f"Skipping variable {self.var_name} due to missing end DIE"
-        )
-        return []
+        for member_name, member_data in member.items():
+            self.variable_map[member_name] = VariableInfo(
+                name=member_name,
+                byte_size=member_data["byte_size"],
+                type=member_data["type"],
+                address=(
+                    self.address + member_data["address_offset"]
+                    if self.address
+                    else None
+                ),
+                array_size=member_data["array_size"],
+                valid_values=member_data["valid_values"],
+            )
 
     def _process_enum_type(self, enum_die):
         """Process an enum type variable and map its members."""
@@ -146,32 +141,16 @@ class GenericParser(ElfParser):
     def _get_end_die(self, current_die):
         """Find the end DIE of a type iteratively."""
         valid_tags = {"DW_TAG_base_type", "DW_TAG_pointer_type", "DW_TAG_structure_type", "DW_TAG_array_type", "DW_TAG_enumeration_type"}
-        while current_die and current_die.tag not in valid_tags:
-            type_attr = current_die.attributes.get("DW_AT_type")
+        ref_addr = None
+        end_die = current_die
+        while end_die and end_die.tag not in valid_tags:
+            type_attr = end_die.attributes.get("DW_AT_type")
             if not type_attr:
                 logging.warning(f"Skipping DIE at offset {current_die.offset} with no 'DW_AT_type'")
-                return None
-            ref_addr = type_attr.value + current_die.cu.cu_offset
-            current_die = self.dwarf_info.get_DIE_from_refaddr(ref_addr)
-        return current_die
-
-    def _process_end_die(self, end_die):
-        """Processes the end DIE of a tag to extract variable information.
-
-        This method NEEDS to add a variable to the variable_map.
-        In case the end_die does not contain a valid variable, it should return.
-        """
-        # Handle Types
-        if end_die.tag == "DW_TAG_pointer_type":
-            pass
-        elif end_die.tag == "DW_TAG_enumeration_type":
-            self._process_enum_type(end_die)
-        elif end_die.tag == "DW_TAG_structure_type":
-            self._process_structure_type(end_die)
-        elif end_die.tag == "DW_TAG_array_type":
-            self._process_array_type(end_die)
-        else:
-            self._process_base_type(end_die)
+                return None, None
+            ref_addr = type_attr.value + end_die.cu.cu_offset
+            end_die = self.dwarf_info.get_DIE_from_refaddr(ref_addr)
+        return end_die, ref_addr
 
     def _extract_address_from_expression(self, expr_value, structs):
         """Extracts an address from DWARF expression.
@@ -230,23 +209,6 @@ class GenericParser(ElfParser):
             die_variable = self.dwarf_info.get_DIE_from_refaddr(spec_ref_addr)
         return die_variable
 
-    def _process_structure_type(self, end_die):
-        """Process a structure type variable."""
-        members = self._get_structure_members(end_die, self.var_name)
-        for member_name, member_data in members.items():
-            self.variable_map[member_name] = VariableInfo(
-                name=member_name,
-                byte_size=member_data["byte_size"],
-                type=member_data["type"],
-                address=(
-                    self.address + member_data["address_offset"]
-                    if self.address
-                    else None
-                ),
-                array_size=member_data["array_size"],
-                valid_values={}
-            )
-
     def _process_array_type(self, end_die):
         """Process an array type variable."""
         array_size = self._get_array_length(end_die)
@@ -255,7 +217,7 @@ class GenericParser(ElfParser):
             base_type_offset = base_type_attr.value + end_die.cu.cu_offset
             base_type_die = self.dwarf_info.get_DIE_from_refaddr(base_type_offset)
             if base_type_die:
-                base_type_die = self._get_end_die(base_type_die)
+                base_type_die, ref_address = self._get_end_die(base_type_die)
                 type_name = base_type_die.attributes.get("DW_AT_name")
                 type_name = type_name.value.decode("utf-8") if type_name else "array"
                 byte_size_attr = base_type_die.attributes.get("DW_AT_byte_size")
@@ -305,17 +267,16 @@ class GenericParser(ElfParser):
         logging.warning(f"Unknown data_member_location value: {value}")
         return None
 
-    def _process_member_array_type(self, member_type_die, member_name, prev_offset, offset):
+    def _process_member_array_type(self, end_die, member_name, prev_offset, offset):
         """Process array type structure members recursively."""
         members = {}
-        end_die = self._get_end_die(member_type_die)
         array_size = self._get_array_length(end_die)
         base_type_attr = end_die.attributes.get("DW_AT_type")
         if base_type_attr:
             base_type_offset = base_type_attr.value + end_die.cu.cu_offset
             base_type_die = self.dwarf_info.get_DIE_from_refaddr(base_type_offset)
             if base_type_die:
-                base_type_die = self._get_end_die(base_type_die)
+                base_type_die, ref_address = self._get_end_die(base_type_die)
                 type_name_attr = base_type_die.attributes.get("DW_AT_name")
                 type_name = (
                     type_name_attr.value.decode("utf-8")
@@ -331,6 +292,7 @@ class GenericParser(ElfParser):
                     "byte_size": array_size * element_byte_size,
                     "address_offset": prev_offset + offset,
                     "array_size": array_size,  # Individual elements aren't arrays
+                    "valid_values": {}
                 }
 
                 # Generate array members
@@ -341,48 +303,59 @@ class GenericParser(ElfParser):
                         "byte_size": element_byte_size,
                         "address_offset": prev_offset + offset + i * element_byte_size,
                         "array_size": 0,  # Individual elements aren't arrays
+                        "valid_values": {}
                     }
         return members
 
-    def _process_structure_member(self, members, child_die, prev_offset, offset, parent_name):
+    def _process_end_die(self, members, child_die, prev_offset, offset, parent_name):
         """Process individual structure member, including handling nested types and arrays."""
-        member = {}
-        type_attr = child_die.attributes.get("DW_AT_type")
-        if type_attr:
-            type_offset = type_attr.value + child_die.cu.cu_offset
-            try:
-                member_type_die = self.dwarf_info.get_DIE_from_refaddr(type_offset)
-                if not member_type_die:
-                    return
+        end_die, type_ref_addr = self._get_end_die(child_die)
+        if end_die is None:
+            return
 
-                if member_type_die.tag == "DW_TAG_array_type":
-                    nested_array_members = self._process_member_array_type(
-                        member_type_die, parent_name, prev_offset, offset
-                    )
-                    members.update(nested_array_members)
-                    return  # Array processing is handled
+        nested_member = {}
+        if end_die.tag == "DW_TAG_pointer_type":
+            pass
+        elif end_die.tag == "DW_TAG_enumeration_type":
+            nested_member = self._process_member_enum_type(end_die, parent_name, prev_offset, offset)
+        elif end_die.tag == "DW_TAG_array_type":
+            nested_member = self._process_member_array_type(end_die, parent_name, prev_offset, offset)
+        elif end_die.tag == "DW_TAG_structure_type":
+            nested_member = self._get_structure_members(end_die, parent_name, prev_offset + offset)
+        else:
+            nested_member = self._process_member_base_type(end_die, parent_name, prev_offset, offset)
 
-                member_type = self._get_member_type(type_offset)
-                if member_type:
-                    member["type"] = member_type["name"]
-                    member["byte_size"] = member_type["byte_size"]
-                    member["address_offset"] = prev_offset + offset
-                    member["array_size"] = self._get_array_length(member_type_die)
-                    members[parent_name] = member
+        members.update(nested_member)
 
-                # Handle nested structures
-                nested_die = self._get_end_die(child_die)
-                if nested_die.tag == "DW_TAG_structure_type":
-                    nested_members, _ = self._get_structure_members_recursive(
-                        nested_die, parent_name, prev_offset + offset
-                    )
-                    if nested_members:
-                        members.update(nested_members)
+    def _process_member_enum_type(self, end_die, parent_name, prev_offset, offset):
+        """Process an enum type variable and map its members."""
+        enum_name_attr = end_die.attributes.get("DW_AT_name")
+        enum_name = (
+            enum_name_attr.value.decode("utf-8") if enum_name_attr else "anonymous_enum"
+        )
 
-            except Exception as e:
-                logging.error(f"Exception processing member '{parent_name}': {e}", exc_info=True)
+        # Dictionary to store enum member names and values
+        enum_members = {}
+        for child in end_die.iter_children():
+            if child.tag == "DW_TAG_enumerator":
+                name_attr = child.attributes.get("DW_AT_name")
+                value_attr = child.attributes.get("DW_AT_const_value")
+                if name_attr and value_attr:
+                    member_name = name_attr.value.decode("utf-8")
+                    member_value = value_attr.value
+                    enum_members[member_name] = member_value
 
-    def _get_structure_members_recursive(self, die, parent_name: str, prev_offset=0):
+        return {
+            parent_name: {
+                "type": f"enum {enum_name}",
+                "byte_size": end_die.attributes.get("DW_AT_byte_size", 0).value,
+                "address_offset": prev_offset + offset,
+                "array_size": 0,
+                "valid_values": enum_members
+            }
+        }
+
+    def _get_structure_members(self, die, parent_name: str, prev_offset=0):
         """Recursively extracts structure members from a DWARF DIE, including arrays."""
         members = {}
         for child_die in die.iter_children():
@@ -395,13 +368,9 @@ class GenericParser(ElfParser):
                 name_attr = child_die.attributes.get("DW_AT_name")
                 if name_attr:
                     member_name += "." + name_attr.value.decode("utf-8")
-                self._process_structure_member(member, child_die, prev_offset, offset, member_name)
+                self._process_end_die(member, child_die, prev_offset, offset, member_name)
                 members.update(member) # member should be varinfo?
-        return members, prev_offset
-
-    def _get_structure_members(self, structure_die, var_name):
-        """Retrieves structure members from a DWARF DIE."""
-        return self._get_structure_members_recursive(structure_die, var_name)[0]
+        return members
 
     @staticmethod
     def _get_array_length(type_die):
@@ -414,28 +383,21 @@ class GenericParser(ElfParser):
                     return array_length
         return 0
 
-    def _get_member_type(self, type_ref_addr):
-        """Retrieve the type information from DWARF given a type offset."""
-        try:
-            type_die = self.dwarf_info.get_DIE_from_refaddr(type_ref_addr)
-        except KeyError:
-            return
-        type_die = self._get_end_die(type_die)
-        if type_die is None:
-            return
-        if type_die.tag == "DW_TAG_base_type":
-            type_name = type_die.attributes["DW_AT_name"].value.decode("utf-8")
-            byte_size_attr = type_die.attributes.get("DW_AT_byte_size")
-            byte_size = byte_size_attr.value if byte_size_attr else None
-            return {
-                "name": type_name,
+    def _process_member_base_type(self, end_die, parent_name, prev_offset, offset):
+        """Process a base type variable."""
+        type_name_attr = end_die.attributes.get("DW_AT_name")
+        type_name = type_name_attr.value.decode("utf-8") if type_name_attr else "base unknown"
+        byte_size_attr = end_die.attributes.get("DW_AT_byte_size")
+        byte_size = byte_size_attr.value if byte_size_attr else None
+        return {
+            parent_name: {
+                "type": type_name,
                 "byte_size": byte_size,
+                "address_offset": prev_offset + offset,
+                "array_size": 0,
+                "valid_values": {}
             }
-        # if we have a different tag than "DW_TAG_base_type", keep on searching
-        base_type_attr = type_die.attributes.get("DW_AT_type")
-        if base_type_attr:
-            base_type_offset = base_type_attr.value
-            return self._get_member_type(base_type_offset)
+        }
 
     def _get_dwarf_die_by_offset(self, offset):
         """Retrieve a DWARF DIE given its offset."""

--- a/pyx2cscope/parser/generic_parser.py
+++ b/pyx2cscope/parser/generic_parser.py
@@ -4,7 +4,6 @@ It focuses on extracting structure members and variable information from DWARF d
 """
 
 import logging
-from email.mime import base
 
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
@@ -220,7 +219,8 @@ class GenericParser(ElfParser):
         variable 'members' with only one element. Considering multidimensional arrays, arrays of
         structs, and arrays of unions, the variable 'members' will have multiple elements, that should
         be considered when calculating the size of the main array element. Afterward, each element need
-        to be added as single indexed element in the array_members variable."""
+        to be added as single indexed element in the array_members variable.
+        """
         members = {}
         array_members = {}
         array_size = self._get_array_length(end_die)

--- a/pyx2cscope/variable/variable.py
+++ b/pyx2cscope/variable/variable.py
@@ -37,6 +37,8 @@ class VariableInfo:
         name (str): The name of the variable.
         type (str): The data type of the variable.
         byte_size (int): The size of the variable in bytes.
+        bit_size (int): bit_size of variable if size is less than a byte (e.g.: union type)
+        bit_offset (int): bit_offset of variable if size is less than a byte (e.g.: union type)
         address (int): The memory address of the variable.
         array_size (int): The size of the array if the variable is an array, default is 0.
         valid_values (dict): enum type of valid values
@@ -45,6 +47,8 @@ class VariableInfo:
     name: str
     type: str
     byte_size: int
+    bit_size: int
+    bit_offset: int
     address: int
     array_size: int
     valid_values: Dict[str, int]

--- a/pyx2cscope/variable/variable_factory.py
+++ b/pyx2cscope/variable/variable_factory.py
@@ -233,15 +233,17 @@ class VariableFactory:
             "unsigned int": VariableUint16,
             "unsigned long": VariableUint32,
             "unsigned long long": VariableUint64,
-            "enum anonymousenum": VariableEnum,
+            "enum": VariableEnum,
         }
 
         try:
 
             var_type: str = var_info.type.lower().replace("_", "")
-            if var_type == "enum anonymousenum":
-                return type_factory[var_type](self.l_net, var_info.address, var_info.array_size, var_info.name, var_info.valid_values)
-            return type_factory[var_type](self.l_net, var_info.address, var_info.array_size, var_info.name)
+            params = [self.l_net, var_info.address, var_info.array_size, var_info.name]
+            if "enum" in var_type:
+                var_type = "enum"
+                params.append(var_info.valid_values)
+            return type_factory[var_type](*params)
         except IndexError:
             raise ValueError(
                 f"Type {var_type} not found. Cannot select the right variable representation."

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -77,6 +77,31 @@ class TestParser:
         assert variable.is_array() == True, "variable should be an array"
         assert len(variable) == array_size_test, "array has wrong length"
 
+    def test_variable_enum_32(self, mocker, size6=6, size3=3):
+        """Given a valid dspic33ck elf file, check if an enum variable is read correctly."""
+        fake_serial(mocker, 32)
+        x2c_scope = X2CScope(port="COM14", elf_file=self.elf_file_32)
+        # test simple variable enum
+        variable = x2c_scope.get_variable("nextGlobalState")
+        assert variable is not None, "variable name not found"
+        assert variable.is_array() == False, "variable should not be an array"
+        assert len(variable.enum_list) == size6, "enum size should be 6"
+        # test nested enum inside a structure
+        variable = x2c_scope.get_variable("mcFoc_State_mds.FocState")
+        assert variable is not None, "variable name not found"
+        assert variable.is_array() == False, "variable should not be an array"
+        assert len(variable.enum_list) == size3, "enum size should be 3"
+
+    def test_variable_enum_16(self, mocker, size6=6):
+        """Given a valid dspic33ck elf file, check if an enum variable is read correctly."""
+        fake_serial(mocker, 32)
+        x2c_scope = X2CScope(port="COM14", elf_file=self.elf_file_16)
+        # test nested enum inside a structure
+        variable = x2c_scope.get_variable("motor.apiData.motorStatus")
+        assert variable is not None, "variable name not found"
+        assert variable.is_array() == False, "variable should not be an array"
+        assert len(variable.enum_list) == size6, "enum size should be 3"
+
     def test_variable_export_import(self, mocker):
         """Given a valid 32 bit elf file, check if export and import functions for variables are working."""
         fake_serial(mocker, 32)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,6 +54,19 @@ class TestParser:
         assert variable.is_array() == True, "variable should be an array"
         assert len(variable) == array_size_test, "array has wrong length"
 
+    def test_union_variable_16(self, mocker):
+        """Given a valid 32 bit elf file, check if an array variable is read correctly."""
+        fake_serial(mocker, 16)
+        x2c_scope = X2CScope(port="COM14", elf_file=self.elf_file_16)
+        variable_lo = x2c_scope.get_variable("motor.vqFiltered.state.x16.lo")
+        variable_hi = x2c_scope.get_variable("motor.vqFiltered.state.x16.hi")
+        variable_union = x2c_scope.get_variable("motor.vqFiltered.state.x32")
+        assert variable_lo is not None, "variable name not found"
+        assert variable_hi is not None, "variable name not found"
+        assert variable_union is not None, "variable name not found"
+        assert variable_lo.address == variable_union.address, "variable union should have the same address as segment"
+        assert variable_hi.address == variable_union.address + 2, "variable high should have address + 2"
+
     def test_variable_dspic33ak(self, mocker, array_size_test=4900, address=22122):
         """Given a valid dspic33ak elf file, check if an array variable is read correctly."""
         fake_serial(mocker, 32)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,7 +54,7 @@ class TestParser:
         assert variable.is_array() == True, "variable should be an array"
         assert len(variable) == array_size_test, "array has wrong length"
 
-    def test_variable_dspic33ak(self, mocker, array_size_test=4900):
+    def test_variable_dspic33ak(self, mocker, array_size_test=4900, address=22122):
         """Given a valid dspic33ak elf file, check if an array variable is read correctly."""
         fake_serial(mocker, 32)
         x2c_scope = X2CScope(port="COM14")
@@ -62,6 +62,7 @@ class TestParser:
         variable = x2c_scope.get_variable("measureInputs.current.Ia")
         assert variable is not None, "variable name not found"
         assert variable.is_array() == False, "variable should be an array"
+        assert variable.address == address, "variable has wrong address, check offset calculation"
         # test array
         variable_array = x2c_scope.get_variable("X2C_BUFFER")
         assert variable_array is not None, "variable name not found"


### PR DESCRIPTION
Enums were not available under a struct variable.
The main issue was that we had two different implementations, one for single variables and one for nested variables, like structs, arrays and unions. Now the code that implements the die variable is done at  ```_process_end_die```

This turns easy to enhance the code and also debug.
This PR also includes functionality for unions. 
bit_size and bit_offset were included into the VariableInfo, but by now only variables with at least 1 byte size can be written and read. 